### PR TITLE
Change invalid watering mode

### DIFF
--- a/custom_components/growcube/coordinator.py
+++ b/custom_components/growcube/coordinator.py
@@ -337,7 +337,7 @@ class GrowcubeDataCoordinator(DataUpdateCoordinator[GrowcubeData]):
             interval,
         )
 
-        command = WateringModeCommand(channel, WateringMode.Manual, interval, duration)
+        command = WateringModeCommand(channel, WateringMode.Scheduled, interval, duration)
         self.client.send_command(command)
 
     async def handle_delete_watering(self, channel: Channel) -> None:


### PR DESCRIPTION
Fixes #12: AttributeError: type object 'WateringMode' has no attribute 'Manual'

Tested by manually changing the attribute on my live HACS setup and seeing the error disappear.